### PR TITLE
feat: Support Azure OpenAI endpoints with API key

### DIFF
--- a/src/Models/OpenAI.cs
+++ b/src/Models/OpenAI.cs
@@ -155,7 +155,11 @@ namespace SourceGit.Models
 
             var client = new HttpClient() { Timeout = TimeSpan.FromSeconds(60) };
             if (!string.IsNullOrEmpty(ApiKey))
+            {
                 client.DefaultRequestHeaders.Add("Authorization", $"Bearer {ApiKey}");
+                // support for Azure open ai endpoints
+                client.DefaultRequestHeaders.Add("api-key", ApiKey);
+            }
 
             var req = new StringContent(JsonSerializer.Serialize(chat, JsonCodeGen.Default.OpenAIChatRequest), Encoding.UTF8, "application/json");
             try


### PR DESCRIPTION
- Add support for Azure OpenAI endpoints by including the API key in request headers.